### PR TITLE
[CR] Add "agenda" overview for upcoming events

### DIFF
--- a/app/views/shows/_agenda.html.haml
+++ b/app/views/shows/_agenda.html.haml
@@ -1,0 +1,7 @@
+%h3
+  Nearest episodes
+
+%ul
+  - upcoming_episodes.limit(3).each do |episode|
+    %li
+      = "#{episode.name} (#{episode.release.strftime('%d/%m')})"

--- a/app/views/shows/index.html.haml
+++ b/app/views/shows/index.html.haml
@@ -2,6 +2,7 @@
   Upcoming episodes
 
 - unless current_user.shows.blank?
+  = render 'agenda'
   = render 'calendar'
 
 = render 'shows'


### PR DESCRIPTION
Fixes #13.

Show three nearest episodes above calendar, with release date.
